### PR TITLE
Add Result.combine

### DIFF
--- a/src/Result/Extra.elm
+++ b/src/Result/Extra.elm
@@ -2,7 +2,7 @@ module Result.Extra where
 {-| Convenience functions for working with Result
 
 # Common Helpers
-@docs isOk, isErr, extract, withDefault
+@docs isOk, isErr, extract, withDefault, combine
 
 -}
 
@@ -43,3 +43,8 @@ withDefault default result =
 
         Err _ ->
             default
+
+{-| Combine a list of results into a single result (holding a list).
+-}
+combine : List (Result x a) -> Result x (List a)
+combine = List.foldr (Result.map2 (::)) (Ok [])


### PR DESCRIPTION
The function corresponds to http://package.elm-lang.org/packages/Apanatshka/elm-signal-extra/5.4.1/Signal-Extra#combine (or to http://hackage.haskell.org/package/base-4.8.1.0/docs/Data-Traversable.html#v:sequenceA).

An example use is [here](https://github.com/elm-lang/core/issues/364#issuecomment-133661718).