### PR TITLE
Add `result`

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.3.1",
+    "version": "1.4.0",
     "summary": "Convenience functions for working with Result",
     "repository": "https://github.com/circuithub/elm-result-extra.git",
     "license": "MIT",

--- a/src/Result/Extra.elm
+++ b/src/Result/Extra.elm
@@ -2,7 +2,7 @@ module Result.Extra where
 {-| Convenience functions for working with Result
 
 # Common Helpers
-@docs isOk, isErr, extract, withDefault, combine
+@docs isOk, isErr, extract, result, withDefault, combine
 
 -}
 
@@ -28,6 +28,17 @@ extract f x = case x of
                 Ok a -> a
                 Err e -> f e
 
+{-| Convert a `Result e a` to a `b` by applying either an error handler or a
+success handler.
+-}
+result : (e -> b) -> (a -> b) -> Result e a -> b
+result onErr onOk result =
+    case result of
+      Ok ok ->
+          onOk ok
+
+      Err err ->
+          onErr err
 
 {-| Returns a `Result`'s contents if the `Result` is an `Ok`,
 or the given default value if the `Result` is an `Err`.

--- a/src/Result/Extra.elm
+++ b/src/Result/Extra.elm
@@ -28,17 +28,18 @@ extract f x = case x of
                 Ok a -> a
                 Err e -> f e
 
-{-| Convert a `Result e a` to a `b` by applying either an error handler or a
-success handler.
+{-| Convert a `Result e a` to a `b` by applying either a function
+if the `Result` is an `Err` or a function if the `Result` is `Ok`.
+Both of these functions must return the same type.
 -}
-result : (e -> b) -> (a -> b) -> Result e a -> b
-result onErr onOk result =
+mapBoth : (e -> b) -> (a -> b) -> Result e a -> b
+mapBoth errFunc okFunc result =
     case result of
-      Ok ok ->
-          onOk ok
+        Ok ok ->
+          okFunc ok
 
-      Err err ->
-          onErr err
+        Err err ->
+          errFunc err
 
 {-| Returns a `Result`'s contents if the `Result` is an `Ok`,
 or the given default value if the `Result` is an `Err`.

--- a/src/Result/Extra.elm
+++ b/src/Result/Extra.elm
@@ -2,7 +2,7 @@ module Result.Extra where
 {-| Convenience functions for working with Result
 
 # Common Helpers
-@docs isOk, isErr, extract, result, withDefault, combine
+@docs isOk, isErr, extract, mapBoth, withDefault, combine
 
 -}
 


### PR DESCRIPTION
`result` maps both "sides" of a Result to a common type.